### PR TITLE
Allow index.html to hold a cached/pre-loaded list of posts

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -28,8 +28,13 @@ type Msg
     | RouteChange Route
 
 
+type alias Flags =
+    { posts : List Post
+    }
+
+
 main =
-    Navigation.program (Route.fromLocation >> RouteChange)
+    Navigation.programWithFlags (Route.fromLocation >> RouteChange)
         { init = init
         , subscriptions = subscriptions
         , update = update
@@ -37,13 +42,13 @@ main =
         }
 
 
-init : Location -> ( Model, Cmd Msg )
-init location =
+init : Flags -> Location -> ( Model, Cmd Msg )
+init flags location =
     let
         route =
             Route.fromLocation location
     in
-    ( Model Visible Loop.init [] route, Cmd.none )
+    ( Model Visible Loop.init flags.posts route, Cmd.none )
 
 
 subscriptions : Model -> Sub Msg

--- a/src/index.html
+++ b/src/index.html
@@ -5,4 +5,8 @@
 <link rel="stylesheet" href="styles.css">
 <script src="main.js"></script>
 <body>
-<script>Elm.Main.embed(document.body);</script>
+<script>
+    // don't edit the next statement: it is search-and-replaced by the cache job.
+    const cache = { posts: [] };
+    Elm.Main.fullscreen(cache);
+</script>


### PR DESCRIPTION
flags are like the initial state for Elm, they don't ever change.
This is missing the python changes to write this out to the html.